### PR TITLE
restore unit structs

### DIFF
--- a/tests/tuple_struct.rs
+++ b/tests/tuple_struct.rs
@@ -21,6 +21,11 @@ struct Car<'a>(std::borrow::Cow<'a, str>);
 #[derive(IntoOwned)]
 struct Dar<'a>(borrow::Cow<'a, str>);
 
+// Unit struct, tested with the tuple structs as it's ... almost the same and the only test case
+// there is for unit structs.
+#[derive(IntoOwned)]
+struct Far;
+
 #[test]
 fn tuple_struct() {
     let non_static_string: String = "foobar".to_string();


### PR DESCRIPTION
it doesn't make much sense for the derive to do this, but it used to be
supported, and I can't really see why it should be dropped. if it should
be dropped, I think we should work on getting a better error message
than just panicing produces.

also adds a test case for this, misplacing it under the tuple_struct
file.

If this sounds good for you, please "rebase merge" this.